### PR TITLE
Rewrite DelayedRetryMiddleware to use async instead of Twisted Deferred

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - Added support for Py3.14; dropped Py3.9
+- Rewrite DelayedRetryMiddleware to use async instead of Twisted Deferred
 
 ## [1.0.2] - 2024-11-18
 


### PR DESCRIPTION
## Description

A short description about the changes in this pull request. If the pull request is related to some issue, mention it
 here.

## Checklist

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
- [ ] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
